### PR TITLE
fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Source code of MOSN and Istio Service Mesh tutorial for [KataCoda](https://www.k
 
 Here are the courses we have supported in the list.
 
-- [MOSN with Istio](https://katacoda.com/mosn/courses/scenarios/mosn-with-istio)
+- [MOSN with Istio](https://katacoda.com/mosn/courses/istio/mosn-with-istio)
 
 ## Contribute
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -8,7 +8,7 @@ MOSN 和 Istio 用于 [KataCoda](https://katacoda.com/mosn) 教程的源码。
 
 当前支持的课程如下。
 
-- [在 Istio 中集成 MOSN](https://katacoda.com/mosn/courses/scenarios/mosn-with-istio)
+- [在 Istio 中集成 MOSN](https://katacoda.com/mosn/courses/istio/mosn-with-istio)
 
 ## 如何贡献
 


### PR DESCRIPTION
Cause the structure of the folder has changed, the katacoda courses need to be updated.